### PR TITLE
Fix bug: non-global regexp replace

### DIFF
--- a/csrf-crypto.js
+++ b/csrf-crypto.js
@@ -43,7 +43,7 @@ module.exports = function csrfCrypto(options) {
 		// Since we use '|' to split parts, make sure that the userData
 		// does not contain that character.
 		getUserData = function (req) {
-			return String(options.userData(req)).replace('|', '^');
+			return String(options.userData(req)).replace(/[|]/g, '^');
 		};
 	}
 

--- a/test/csrf-crypto-tests.js
+++ b/test/csrf-crypto-tests.js
@@ -157,10 +157,10 @@ describe('#csrfCrypto', function () {
 	it('should work with users', function () {
 		var session = new Session({ key: 'abc', userData: getUser });
 
-		var res1 = session.run({ user: "2|SLaks" });
+		var res1 = session.run({ user: "2|SLaks|:)" });
 		var formToken = res1.getFormToken();
 
-		var req2 = { user: "2|SLaks" };
+		var req2 = { user: "2|SLaks|:)" };
 		session.run(req2);
 		assert.ok(req2.verifyToken(formToken));
 	});


### PR DESCRIPTION
[String.prototype.replace()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace#Parameters) says

> substr (pattern)
>
> A String that is to be replaced by newSubStr. It is treated as a verbatim string and is not interpreted as a regular expression. **Only the first occurrence will be replaced.**

```js
'||'.replace('|', '^') === '^|' && '||'.replace(/[|]/g, '^') === '^^'
```
